### PR TITLE
Fixed typo in wget url

### DIFF
--- a/_hands-on/linux_prerequisites/basic-linux-commands.md
+++ b/_hands-on/linux_prerequisites/basic-linux-commands.md
@@ -36,7 +36,7 @@ title: Tutorial - Basic linux commands
 
 1. Download a file into this new folder. Use the command `wget` for downloading from an URL:
     ```bash
-    wget https://github.com/CSCfi/csc-env-eff/raw/master/hands-on/linux_prerequisites/my-first-file.txt
+    wget https://github.com/csc-training/csc-env-eff/raw/master/_hands-on/linux_prerequisites/my-first-file.txt
     ```
 2. Check what kind of file did you get and what size it is using `ls` command with some extra parameters:
     ```bash


### PR DESCRIPTION
Fixed broken URL in command `wget https://raw.githubusercontent.com/csc-training/csc-env-eff/master/_hands-on/linux_prerequisites/my-first-file.txt` in basic-linux-commands.md