### PR TITLE
License auth

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
 Copyright (C) 2020-2021  CSC - IT Center for Science Ltd. except where otherwise noted
 
-This work is licensed under a Creative Commons Non Commercial Attribution-ShareAlike 4.0 International License, except where otherwise noted.
-Full text of the license is available at <https://creativecommons.org/licenses/by-nc-sa/4.0/>.
+This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License, except where otherwise noted.
+Full text of the license is available at <https://creativecommons.org/licenses/by-sa/4.0/>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2020-2021  CSC - IT Center for Science Ltd. expect where otherwise noted
+Copyright (C) 2020-2021  CSC - IT Center for Science Ltd. except where otherwise noted
 
-This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License, expect where otherwise noted.
-Full text of the license is available at <https://creativecommons.org/licenses/by-sa/4.0/>.
+This work is licensed under a Creative Commons Non Commercial Attribution-ShareAlike 4.0 International License, except where otherwise noted.
+Full text of the license is available at <https://creativecommons.org/licenses/by-nc-sa/4.0/>.

--- a/index.md
+++ b/index.md
@@ -135,9 +135,9 @@ author: CSC Training
   <div style="float: right; width: 50%;">
     <img src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png" width=200>
     <p><small>
-  All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors. <br />
+  All material (C) 2020-2021 by CSC -IT Center for Science Ltd.  <br />
   This work is licensed under a <strong>Creative Commons Attribution-NonCommercial-ShareAlike</strong> 3.0 <br />
-  Unported License, <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">http://creativecommons.org/licenses/by-nc-sa/3.0/</a>
+  Unported License, <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">http://creativecommons.org/licenses/by-nc-sa/4.0/</a>
       </small>
     </p>
   </div>

--- a/index.md
+++ b/index.md
@@ -133,11 +133,11 @@ author: CSC Training
     </p>
   </div>
   <div style="float: right; width: 50%;">
-    <img src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png" width=200>
+    <img src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png" width=180>
     <p><small>
   All material (C) 2020-2021 by CSC -IT Center for Science Ltd.  <br />
-  This work is licensed under a <strong>Creative Commons Attribution-NonCommercial-ShareAlike</strong> 3.0 <br />
-  Unported License, <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">http://creativecommons.org/licenses/by-nc-sa/4.0/</a>
+  This work is licensed under a <strong>Creative Commons Attribution-ShareAlike</strong> 3.0 <br />
+  Unported License, <a href="http://creativecommons.org/licenses/by-sa/4.0/">http://creativecommons.org/licenses/by-sa/4.0/</a>
       </small>
     </p>
   </div>

--- a/slides/00_account_and_project.md
+++ b/slides/00_account_and_project.md
@@ -8,13 +8,13 @@ lang: en
 This topic is about what CSC accounts and projects are for and how to manage them.
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/00_account_and_project.md
+++ b/slides/00_account_and_project.md
@@ -12,9 +12,9 @@ This topic is about what CSC accounts and projects are for and how to manage the
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/00_account_and_project.md
+++ b/slides/00_account_and_project.md
@@ -13,7 +13,7 @@ This topic is about what CSC accounts and projects are for and how to manage the
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/00_study_tips.md
+++ b/slides/00_study_tips.md
@@ -12,7 +12,7 @@ How to use the material and hot to solve the common problems.
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/00_study_tips.md
+++ b/slides/00_study_tips.md
@@ -7,13 +7,13 @@ lang: en
 How to use the material and hot to solve the common problems.
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/00_study_tips.md
+++ b/slides/00_study_tips.md
@@ -11,9 +11,9 @@ How to use the material and hot to solve the common problems.
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/01_logging_in.md
+++ b/slides/01_logging_in.md
@@ -12,9 +12,9 @@ This topic is about how to login on CSC supercomputers with ssh and NoMachine.
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/01_logging_in.md
+++ b/slides/01_logging_in.md
@@ -13,7 +13,7 @@ This topic is about how to login on CSC supercomputers with ssh and NoMachine.
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/01_logging_in.md
+++ b/slides/01_logging_in.md
@@ -8,13 +8,13 @@ lang: en
 This topic is about how to login on CSC supercomputers with ssh and NoMachine.
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/02_environment.md
+++ b/slides/02_environment.md
@@ -11,7 +11,7 @@ lang: en
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/02_environment.md
+++ b/slides/02_environment.md
@@ -6,13 +6,13 @@ lang: en
 # Brief introduction to HPC environments {.title}
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/02_environment.md
+++ b/slides/02_environment.md
@@ -10,9 +10,9 @@ lang: en
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/03_disk_areas.md
+++ b/slides/03_disk_areas.md
@@ -12,7 +12,7 @@ In this section, you will learn how to manage different disk areas in HPC enviro
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/03_disk_areas.md
+++ b/slides/03_disk_areas.md
@@ -7,13 +7,13 @@ lang: en
 In this section, you will learn how to manage different disk areas in HPC environment at CSC
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/03_disk_areas.md
+++ b/slides/03_disk_areas.md
@@ -11,9 +11,9 @@ In this section, you will learn how to manage different disk areas in HPC enviro
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/04_modules.md
+++ b/slides/04_modules.md
@@ -14,7 +14,7 @@ Same information can be found in [the module section of our user guide at docs.c
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/04_modules.md
+++ b/slides/04_modules.md
@@ -13,9 +13,9 @@ Same information can be found in [the module section of our user guide at docs.c
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/04_modules.md
+++ b/slides/04_modules.md
@@ -9,13 +9,13 @@ Module systems and how to use them in CSC supercomputers.
 Same information can be found in [the module section of our user guide at docs.csc.fi](https://docs.csc.fi/computing/modules/)
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/05_batch_jobs.md
+++ b/slides/05_batch_jobs.md
@@ -11,7 +11,7 @@ lang: en
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/05_batch_jobs.md
+++ b/slides/05_batch_jobs.md
@@ -6,13 +6,13 @@ lang: en
 # The batch job system in CSC's HPC environment {.title}
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/05_batch_jobs.md
+++ b/slides/05_batch_jobs.md
@@ -10,9 +10,9 @@ lang: en
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/06_understanding_usage.md
+++ b/slides/06_understanding_usage.md
@@ -11,7 +11,7 @@ lang: en
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/06_understanding_usage.md
+++ b/slides/06_understanding_usage.md
@@ -10,9 +10,9 @@ lang: en
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/06_understanding_usage.md
+++ b/slides/06_understanding_usage.md
@@ -6,13 +6,13 @@ lang: en
 # Understanding resource usage in CSC's HPC environment {.title}
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/07_allas.md
+++ b/slides/07_allas.md
@@ -13,7 +13,7 @@ This topic is about using Allas and storing data.
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/07_allas.md
+++ b/slides/07_allas.md
@@ -8,13 +8,13 @@ lang: en
 This topic is about using Allas and storing data.
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/07_allas.md
+++ b/slides/07_allas.md
@@ -12,9 +12,9 @@ This topic is about using Allas and storing data.
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/08_installing.md
+++ b/slides/08_installing.md
@@ -12,9 +12,9 @@ This topic is about installing your own software on CSC servers.
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/08_installing.md
+++ b/slides/08_installing.md
@@ -8,13 +8,13 @@ lang: en
 This topic is about installing your own software on CSC servers.
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/08_installing.md
+++ b/slides/08_installing.md
@@ -13,7 +13,7 @@ This topic is about installing your own software on CSC servers.
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/09_singularity.md
+++ b/slides/09_singularity.md
@@ -6,13 +6,13 @@ lang: en
 # Introduction to Singularity containers {.title}
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/09_singularity.md
+++ b/slides/09_singularity.md
@@ -11,7 +11,7 @@ lang: en
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/09_singularity.md
+++ b/slides/09_singularity.md
@@ -10,9 +10,9 @@ lang: en
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/10_speed_up_jobs.md
+++ b/slides/10_speed_up_jobs.md
@@ -11,7 +11,7 @@ lang: en
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+This work is licensed under a **Creative Commons Attribution-ShareAlike** 4.0
 Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>

--- a/slides/10_speed_up_jobs.md
+++ b/slides/10_speed_up_jobs.md
@@ -6,13 +6,13 @@ lang: en
 # Not fast enough? How HPC can help. {.title}
 
 <div class="column">
-![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png)
+![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
 </div>
 <div class="column">
 <small>
 All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
 This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creativecommons.org/licenses/by-sa/4.0/)
 </small>
 </div>
 

--- a/slides/10_speed_up_jobs.md
+++ b/slides/10_speed_up_jobs.md
@@ -10,9 +10,9 @@ lang: en
 </div>
 <div class="column">
 <small>
-All material (C) 2020-2021 by CSC -IT Center for Science Ltd. and the authors.
-This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 3.0
-Unported License, [http://creativecommons.org/licenses/by-nc-sa/3.0/](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+All material (C) 2020-2021 by CSC -IT Center for Science Ltd.
+This work is licensed under a **Creative Commons Attribution-NonCommercial-ShareAlike** 4.0
+Unported License, [http://creativecommons.org/licenses/by-nc-sa/4.0/](http://creativecommons.org/licenses/by-nc-sa/4.0/)
 </small>
 </div>
 

--- a/slides/Makefile
+++ b/slides/Makefile
@@ -1,5 +1,6 @@
 LECTURES= \
 00_study_tips.md \
+00_account_and_project.md \
 01_logging_in.md \
 02_environment.md \
 03_disk_areas.md \
@@ -11,7 +12,7 @@ LECTURES= \
 09_singularity.md \
 10_speed_up_jobs.md \
 csc-env.md
-# README.md creates the index for allas
+# csc-env.md creates the index for allas
 
 TITLE=Title.pdf
 


### PR DESCRIPTION
old license had authors mentioned separately. Since the content has been developed by people at CSC, reference to CSC should suffice (and make it easier for others to use and credit us). "individual authors" were removed.

CSC open source policy () recommends using CC-BY-4.0. This repo used CC-NC-BY-3.0. Version was upgraded, whether to use NC or not?