### PR TITLE
Update theme with EuroCC-logo, edit contribute guide

### DIFF
--- a/contribute_guide/MD_into_html.md
+++ b/contribute_guide/MD_into_html.md
@@ -2,24 +2,24 @@
 
 ## Copy the Singularity tool image to Puhti. (*e.g.* in `$HOME/bin` which is used in the examples below)
    - Initialize Allas with project_2001659 (see below, works only for CSC staff)
-   - `a-get pandocTool/pandoc.sif`
-   - Give execute permissions `chmod u+x pandoc.sif`
+   - `a-get pandocTool/pandoc-eurocc.sif`. This container contains the new EuroCC slide theme, please use instead of the old `pandoc.sif`
+   - Give execute permissions `chmod u+x pandoc-eurocc.sif`
 
 ## Copy the theme and other dependencies to local directory (in Puhti)
 
 1. Go the the same directory as the source md files (= your git root directory for csc-env-eff in Puhti) (If you haven't yet cloned the repository, do so: `git clone https://github.com/csc-training/csc-env-eff`). Note, this must be a subfolder in your `$HOME`.
 2. Run command 
    ```bash
-   singularity exec $HOME/bin/pandoc.sif /bin/sh -c "cp -r /slidetools/* ."
+   singularity exec $HOME/bin/pandoc-eurocc.sif /bin/sh -c "cp -r /slidetools/* ."
    ```
 3. Now you can transform the md files to html faster and without font 
    embedding using simple command 
    ```bash
-   $HOME/bin/pandoc.sif 01_my_lecture.md
+   $HOME/bin/pandoc-eurocc.sif 01_my_lecture.md
    ```
 4. To create a self contained html *slide* page add `-s` *i.e.* instead
    ```bash
-   $HOME/bin/pandoc.sif -s 01_my_lecture.md
+   $HOME/bin/pandoc-eurocc.sif -s 01_my_lecture.md
    ```
 5. To create the whole site add your page to the top of the Makefile (located in: csc-env-eff/slides/Makefile) list and run `make`
 

--- a/contribute_guide/STYLEGUIDE.md
+++ b/contribute_guide/STYLEGUIDE.md
@@ -4,6 +4,7 @@
  - For tutorials and exercises please see [this Markdown syntax guide](https://www.markdownguide.org/tools/mkdocs/) and [this Markdown example tutorial](../_hands-on/example_tutorial.md)
  - For Slides, [see this syntax guide](https://github.com/csc-training/slide-template/blob/master/docs/syntax-guide.md)
    and [this Markdown example slide set](../slides/example.md)
+ - Please use the csc-eurocc-2019 theme
  - When in doubt, check how other pages are formatted
 
 ## Organizing content

--- a/slides/00_account_and_project.md
+++ b/slides/00_account_and_project.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/00_study_tips.md
+++ b/slides/00_study_tips.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 # Study tips and problem solving {.title}

--- a/slides/01_logging_in.md
+++ b/slides/01_logging_in.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/02_environment.md
+++ b/slides/02_environment.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/03_disk_areas.md
+++ b/slides/03_disk_areas.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/04_modules.md
+++ b/slides/04_modules.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/05_batch_jobs.md
+++ b/slides/05_batch_jobs.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/06_understanding_usage.md
+++ b/slides/06_understanding_usage.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/07_allas.md
+++ b/slides/07_allas.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/08_installing.md
+++ b/slides/08_installing.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/09_singularity.md
+++ b/slides/09_singularity.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/10_speed_up_jobs.md
+++ b/slides/10_speed_up_jobs.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/Makefile
+++ b/slides/Makefile
@@ -19,8 +19,8 @@ TITLE=Title.pdf
 PRESS=csc-env-press.pdf
 HANDOUT=csc-env--handout.pdf
 
-#PANDOC=$(HOME)/bin/pandoc.sif
-PANDOC=pandoc.sif   # Cases when pandoc is elsewhere and that folder is in PATH
+#PANDOC=$(HOME)/bin/pandoc-eurocc.sif
+PANDOC=pandoc-eurocc.sif   # Cases when pandoc is elsewhere and that folder is in PATH
 
 HTMLS:=$(patsubst %.md,%.html,$(LECTURES))
 PDFS:=$(patsubst %.md,%.pdf,$(LECTURES))

--- a/slides/csc-env.md
+++ b/slides/csc-env.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 

--- a/slides/example.md
+++ b/slides/example.md
@@ -1,5 +1,5 @@
 ---
-theme: csc-2019
+theme: csc-eurocc-2019
 lang: en
 ---
 


### PR DESCRIPTION
Added slide theme with EuroCC-logo. From now on, please use the theme csc-eurocc-2019. This theme is contained in a new container in Allas, pandocTool/pandoc-eurocc.sif