### PR TITLE
Deprecated NoMachine

### DIFF
--- a/_hands-on/batch_jobs/interactive.md
+++ b/_hands-on/batch_jobs/interactive.md
@@ -18,7 +18,7 @@ title: Tutorial - Interactive batch jobs
 - For heavy interactive tasks one can request specific resources (time, memory, cores, disk). 
 
 💡 You can also use tools with graphical user interfaces in an interactive shell session. 
-- For such usage the [NoMachine](https://docs.csc.fi/support/tutorials/nomachine-usage/) remote desktop often provides an improved experience. 
+- For such usage the [Web Interface](https://www.puhti.csc.fi/) remote desktop often provides an improved experience. 
 - Check also [how to use RStudio and Jupyter Notebook in Puhti](https://docs.csc.fi/support/tutorials/rstudio-or-jupyter-notebooks/) 
 
 ### A simple interactive job 

--- a/_hands-on/connecting/README.md
+++ b/_hands-on/connecting/README.md
@@ -3,7 +3,6 @@
 ## Tutorials
 * [Login Puhti with ssh](ssh-puhti.md)
 * [Create SSH-keys](ssh-keys.md)
-* [Login Puhti with NoMachine and run gnuplot](https://docs.csc.fi/support/tutorials/nomachine-usage/) (Advanced)
 * [Run R studio/Jupyter Notebook on Puhti via ssh-tunnel and browser](https://docs.csc.fi/support/tutorials/rstudio-or-jupyter-notebooks/) This requires ssh-keys (see above) but is the recommended way to use these interactive tools. (Advanced)
 
 ## Exercises

--- a/_hands-on/connecting/ssh-puhti.md
+++ b/_hands-on/connecting/ssh-puhti.md
@@ -116,7 +116,7 @@ Last login: Mon Dec 14 14:53:15 2020 from jabadabaduu.fi
 #### In Windows 
 1. MobaXterm actually will tunnel the connection by default.
 
-☝🏻 For intensive remote graphics we recommend using [NoMachine](https://docs.csc.fi/apps/nomachine/).
+☝🏻 For intensive remote graphics we recommend using the [Web Interface](https://www.puhti.csc.fi/).
 
 
 ## More information

--- a/slides/01_logging_in.md
+++ b/slides/01_logging_in.md
@@ -5,7 +5,7 @@ lang: en
 
 # Connecting to CSC Computers {.title}
 
-This topic is about how to login on CSC supercomputers with ssh and NoMachine.
+This topic is about how to login on CSC supercomputers with ssh and Web Interface.
 
 <div class="column">
 ![](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png)
@@ -36,14 +36,6 @@ Unported License, [http://creativecommons.org/licenses/by-sa/4.0/](http://creati
    - Note the [prerequisites to be able to access Puhti](https://docs.csc.fi/support/faq/how-to-get-puhti-access/)
 - Plain ssh will not allow displaying remote graphics
    - It can be enabled by tunneling, but on Windows it will require additional installations, see the link above. 
-
-# Log in via NoMachine
-
-- NoMachine is a software that makes remote graphics easier, like using a graphical user interface (GUI)
-   - Note that for example [R Studio](https://docs.csc.fi/apps/r-env-singularity/) and [Jupyter Notebooks](https://docs.csc.fi/computing/running/interactive-usage/#example-running-a-jupyter-notebook-server-via-sinteractive) can easily be run from the Puhti web interface (first slide).
-- NoMachine client must be installed locally on your computer first (This may require admin privileges).
-- [The client is used to connect to a server in Kajaani](https://docs.csc.fi/apps/nomachine/) and it provides faster graphical performance than X11-forwarding
-- Please first consult the [Instructions on how to install and to use NoMachine](https://docs.csc.fi/support/tutorials/nomachine-usage/)
 
 # Moving files between local computer and Puhti
 


### PR DESCRIPTION
Removed references to NoMachine. Replaced them with references to web interface instead. I left the link to NoMachine tutorial in Docs. It is marked as "Advanced", so I think it's ok to include even if we don't cover it in the lectures.