### PR TITLE
Update course name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Using CSC HPC Environment Efficiently
+# CSC Computing Environment
 
-This is the _source_ repository for training material. We welcome contributions!
+This is the _source_ repository for training material for the _CSC Computing Environment_ -course (previously known as _Using CSC HPC Environment Efficiently_). We welcome contributions!
 > The slides and the hands-on tutorials and exercises are available via: https://csc-training.github.io/csc-env-eff/

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: Using CSC HPC Environment Efficiently
+title: CSC Computing Environment
 
 plugins:
   - jekyll-sitemap

--- a/index.md
+++ b/index.md
@@ -1,9 +1,9 @@
 ---
-title: Using CSC HPC Environment Efficiently
+title: CSC Computing Environment
 author: CSC Training
 ---
 
-# Material for _Using CSC HPC Environment Efficiently_ -course
+# Material for _CSC Computing Environment_ -course
 
 {% assign items = site.hands-on |  sort: "title" | reverse %}
 

--- a/slides/csc-env.md
+++ b/slides/csc-env.md
@@ -3,7 +3,7 @@ theme: csc-eurocc-2019
 lang: en
 ---
 
-# Using CSC HPC Environment Efficiently
+# CSC Computing Environment
 
 These slides are used e.g. in e-learn.csc.fi, docs.csc.fi and
 hopefully at Universities' own materials introducing high


### PR DESCRIPTION
Changed all occurrences of "Using CSC HPC Environment Efficiently" to "CSC Computing Environment". Added a note in `README.md` that the course was formerly known as "Using CSC HPC Environment Efficiently".