### PR TITLE
Matomo migration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,3 +40,8 @@ callouts:
     color: blue
   highlight:
     color: yellow
+
+# Matomo configuration
+matomo:
+  url: docs-design-matomo.rahtiapp.fi
+  site_id: 4

--- a/_config.yml
+++ b/_config.yml
@@ -43,5 +43,5 @@ callouts:
 
 # Matomo configuration
 matomo:
-  url: docs-design-matomo.rahtiapp.fi
+  url: mwa-acf.2.rahtiapp.fi
   site_id: 4

--- a/_includes/matomo.html
+++ b/_includes/matomo.html
@@ -5,9 +5,9 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="//docs-design-matomo.rahtiapp.fi/";
+    var u="//{{ site.matomo.url }}/";
     _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '4']);
+    _paq.push(['setSiteId', '{{ site.matomo.site_id }}']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();


### PR DESCRIPTION
Preparing to migrate the Matomo instance.

I took the opportunity to move the Matomo settings from hardcoded values to the config file. It would've been nicer to put them in the environment, but Jekyll doesn't seem to have a mechanism in place to read custom environment variables while building the site.