### PR TITLE
Add warning callout to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,9 @@ callouts:
     color: blue
   highlight:
     color: yellow
+  warning:
+    title: Warning!
+    color: red
 
 # Matomo configuration
 matomo:


### PR DESCRIPTION
This warning can be used like on the old page (https://github.com/csc-training/csc-env-eff-old/commit/fc90bb00da681beaacd998b00c6689797f969e3b)

e.g.
{: .warning }
**This website contains materials related to the Roihu supercomputer that are still under active development. Some sections may still contain old information. Materials related to the retiring Mahti and Puhti supercomputers can be found [here](https://csc-training.github.io/csc-env-eff-old/).**
